### PR TITLE
Allow kunalvarma05/dropbox-php-sdk releases 0.3 and 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.6.0",
     	"league/flysystem": "^1.0",
-        "kunalvarma05/dropbox-php-sdk": "^0.2.2"
+        "kunalvarma05/dropbox-php-sdk": "^0.2.2|^0.3|^0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
There have been later releases of kunalvarma05/dropbox-php-sdk - allow them to be used.

I locally ran the PHP unit tests with kunalvarma05/dropbox-php-sdk 0.4.0 and they passed.